### PR TITLE
Make flux-trace not use less

### DIFF
--- a/plugins/flux_trace.yaml
+++ b/plugins/flux_trace.yaml
@@ -16,5 +16,5 @@ flux_trace:
       --namespace="$NAMESPACE"
       --kind=$(echo "$RESOURCE_NAME" | sed -E 's/ies$/y/' | sed -E 's/ses$/se/' | sed -E 's/(s)$//')
       --api-version="$RESOURCE_GROUP/$RESOURCE_VERSION"
-      "$NAME"
-      | less --CLEAR-SCREEN
+      "$NAME";
+      IFS= read -rsn1 _


### PR DESCRIPTION
Remove less from flux-trace and wait for any keypress.

Though this solution is risking a situation when part of the trace will not be visible, it seems like a much better UX to be able to ESCape out of the trace output.